### PR TITLE
Add authz to meter creation endpoint (uses allow list, zcaps, and http-sigs).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.0 - 2021-09-xx
 - **BREAKING**: A capability invocation via http-sigs is required to create
-  meters. Access is controlled via the `config.createMeterAllowList`
+  meters. Access is controlled via the `config.meterCreationAllowList`
   configuration.
 
 ## 2.0.0 - 2021-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0.0 - 2021-09-xx
 - **BREAKING**: A capability invocation via http-sigs is required to create
   meters. Access is controlled via the `config.createMeterAllowList`
-  configuration/
+  configuration.
 
 ## 2.0.0 - 2021-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.0 - 2021-08-31
 
 ### Changed
-- **BREAKING**: A a meter usage zcap is no longer generated, instead the
+- **BREAKING**: A meter usage zcap is no longer generated, instead the
   service ID associated with a meter is set as the root controller for the
   meter's usage endpoint. The service can then invoke (or delegate) the root
   zcap for that endpoint. This simplifies setup, and key and zcap management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-meter-http ChangeLog
 
+## 3.0.0 - 2021-09-xx
+- **BREAKING**: A capability invocation via http-sigs is required to create
+  meters. Access is controlled via the `config.createMeterAllowList`
+  configuration/
+
 ## 2.0.0 - 2021-08-31
 
 ### Changed

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,7 @@ const namespace = 'meter-http';
 const cfg = config[namespace] = {};
 
 // list of allowed applications that can create meters
-cfg.createMeterAllowList = [
+cfg.meterCreationAllowList = [
   // default "app" id found in `bedrock-app-identity`
   'did:key:z6MksNZwi2r6Qxjt3MYLrrZ44gs2fauzgv1dk4E372bNVjtc'
 ];

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,12 @@ const {config} = bedrock;
 const namespace = 'meter-http';
 const cfg = config[namespace] = {};
 
+// list of allowed applications that can create meters
+cfg.createMeterAllowList = [
+  // default "app" id found in `bedrock-app-identity`
+  'did:key:z6MksNZwi2r6Qxjt3MYLrrZ44gs2fauzgv1dk4E372bNVjtc'
+];
+
 const basePath = '/meters';
 cfg.routes = {
   basePath

--- a/lib/http.js
+++ b/lib/http.js
@@ -45,7 +45,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       getRootController() {
         const cfg = bedrock.config['meter-http'];
         // root controller(s) for meter creation is found in its allow list
-        return cfg.createMeterAllowList;
+        return cfg.meterCreationAllowList;
       }
     }),
     // FIXME: add validation; do not allow client to set `serviceId`

--- a/lib/http.js
+++ b/lib/http.js
@@ -37,6 +37,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.post(
     routes.basePath,
     cors(),
+    _createAuthorizeMiddleware({
+      getExpectedTarget({req}) {
+        const expectedTarget = `https://${req.get('host')}${routes.basePath}`;
+        return {expectedTarget};
+      },
+      getRootController() {
+        const cfg = bedrock.config['meter-http'];
+        // root controller(s) for meter creation is found in its allow list
+        return cfg.createMeterAllowList;
+      }
+    }),
     // FIXME: add validation; do not allow client to set `serviceId`
     //validate({bodySchema: postMeterBody}),
     asyncHandler(async (req, res) => {

--- a/test/package.json
+++ b/test/package.json
@@ -4,12 +4,15 @@
   "private": true,
   "scripts": {
     "test": "node --preserve-symlinks test.js test",
+    "test:debug": "node --preserve-symlinks test.js test --log-level debug",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm test",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm test",
     "coverage-report": "nyc report"
   },
   "dependencies": {
+    "@digitalbazaar/http-client": "^1.2.0",
     "bedrock": "^4.1.1",
+    "bedrock-app-identity": "^1.0.0",
     "bedrock-did-io": "^4.0.0",
     "bedrock-express": "^4.0.0",
     "bedrock-https-agent": "^2.0.0",
@@ -20,6 +23,7 @@
     "bedrock-server": "^2.7.0",
     "bedrock-test": "^5.3.2",
     "cross-env": "^7.0.3",
+    "http-signature-zcap-invoke": "^3.0.0",
     "nyc": "^15.1.0"
   },
   "nyc": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const bedrock = require('bedrock');
+require('bedrock-app-identity');
 require('bedrock-https-agent');
 require('bedrock-mongodb');
 const {handlers} = require('bedrock-meter-http');


### PR DESCRIPTION
@dlongley What color would you like the bike shed? It's currently painted `config.createMeterAllowList`.